### PR TITLE
removed --allow-all-external

### DIFF
--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -25,5 +25,5 @@ fi
 
 if [ -f requirements.txt ]; then
     puts-step "Installing dependencies using Pip"
-    pip install -r requirements.txt  --exists-action=w --allow-all-external | indent
+    pip install -r requirements.txt  --exists-action=w | indent
 fi


### PR DESCRIPTION
according to new pip version "Removed the deprecated --allow-external, --allow-all-external, and --allow-unverified options. (#3070)", without removing this buildpack doesn't work